### PR TITLE
Changed mode of /var/log/nova to 0750

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -125,7 +125,7 @@ class nova(
 
   file { $logdir:
     ensure  => directory,
-    mode    => '0751',
+    mode    => '0750',
   }
   file { '/etc/nova/nova.conf':
     mode  => '0640',

--- a/spec/classes/nova_init_spec.rb
+++ b/spec/classes/nova_init_spec.rb
@@ -36,7 +36,7 @@ describe 'nova' do
 
     it { should contain_file('/var/log/nova').with(
       'ensure'  => 'directory',
-      'mode'    => '0751',
+      'mode'    => '0750',
       'owner'   => 'nova',
       'group'   => 'nova',
       'require' => 'Package[nova-common]'


### PR DESCRIPTION
If directory is world executable, it means when somebody
knows proper filenames (and everybody knows default names)
then the directory is "vulnerable".
