### PR TITLE
auto assign floating ip patch

### DIFF
--- a/manifests/network/flatdhcp.pp
+++ b/manifests/network/flatdhcp.pp
@@ -6,6 +6,7 @@ class nova::network::flatdhcp (
   $flat_network_bridge = 'br100',
   $force_dhcp_release  = true,
   $flat_injected       = false,
+  $auto_assign_floating_ip = true,
   $dhcp_domain         = 'novalocal',
   $dhcpbridge          = '/usr/bin/nova-dhcpbridge',
   $dhcpbridge_flagfile = '/etc/nova/nova.conf'
@@ -26,6 +27,7 @@ class nova::network::flatdhcp (
     'DEFAULT/flat_network_bridge': value => $flat_network_bridge;
     'DEFAULT/force_dhcp_release':  value => $force_dhcp_release;
     'DEFAULT/flat_injected':       value => $flat_injected;
+    'DEFAULT/auto_assign_floating_ip':       value => $auto_assign_floating_ip;
     'DEFAULT/dhcp_domain':         value => $dhcp_domain;
     'DEFAULT/dhcpbridge':          value => $dhcpbridge;
     'DEFAULT/dhcpbridge_flagfile': value => $dhcpbridge_flagfile;

--- a/spec/classes/nova_network_flatdhcp_spec.rb
+++ b/spec/classes/nova_network_flatdhcp_spec.rb
@@ -18,6 +18,7 @@ describe 'nova::network::flatdhcp' do
     it { should contain_nova_config('DEFAULT/flat_network_bridge').with_value('br100') }
     it { should contain_nova_config('DEFAULT/force_dhcp_release').with_value('true') }
     it { should contain_nova_config('DEFAULT/flat_injected').with_value('false') }
+    it { should contain_nova_config('DEFAULT/auto_assign_floating_ip').with_value('false') }
     it { should contain_nova_config('DEFAULT/dhcpbridge').with_value('/usr/bin/nova-dhcpbridge') }
     it { should contain_nova_config('DEFAULT/dhcpbridge_flagfile').with_value('/etc/nova/nova.conf') }
   end
@@ -32,6 +33,7 @@ describe 'nova::network::flatdhcp' do
         :flat_network_bridge => 'br1001',
         :force_dhcp_release  => false,
         :flat_injected       => true,
+        :auto_assign_floating_ip       => true,
         :dhcpbridge          => '/usr/bin/dhcpbridge',
         :dhcpbridge_flagfile => '/etc/nova/nova-dhcp.conf'
       }
@@ -41,6 +43,7 @@ describe 'nova::network::flatdhcp' do
     it { should contain_nova_config('DEFAULT/flat_network_bridge').with_value('br1001') }
     it { should contain_nova_config('DEFAULT/force_dhcp_release').with_value('false') }
     it { should contain_nova_config('DEFAULT/flat_injected').with_value('true') }
+    it { should contain_nova_config('DEFAULT/auto_assign_floating_ip').with_value('true') }
     it { should contain_nova_config('DEFAULT/dhcpbridge').with_value('/usr/bin/dhcpbridge') }
     it { should contain_nova_config('DEFAULT/dhcpbridge_flagfile').with_value('/etc/nova/nova-dhcp.conf') }
 

--- a/spec/classes/nova_network_spec.rb
+++ b/spec/classes/nova_network_spec.rb
@@ -106,6 +106,7 @@ describe 'nova::network' do
           :flat_network_bridge  => 'br100',
           :force_dhcp_release   => true,
           :flat_injected        => false,
+          :auto_assign_floating_ip => false,
           :dhcp_domain          => 'novalocal',
           :dhcpbridge           => '/usr/bin/nova-dhcpbridge',
           :dhcpbridge_flagfile  => '/etc/nova/nova.conf'
@@ -121,6 +122,7 @@ describe 'nova::network' do
                     'flat_network_bridge' => 'br400',
                     'force_dhcp_release'  => false,
                     'flat_injected'       => true,
+                    'auto_assign_floating_ip' => true,
                     'dhcp_domain'         => 'not-novalocal',
                     'dhcpbridge'          => '/tmp/bridge',
                     'dhcpbridge_flagfile' => '/tmp/file',
@@ -135,6 +137,7 @@ describe 'nova::network' do
             :flat_network_bridge  => 'br400',
             #:force_dhcp_release   => false,
             :flat_injected        => true,
+            :auto_assign_floating_ip => true,
             :dhcp_domain          => 'not-novalocal',
             :dhcpbridge           => '/tmp/bridge',
             :dhcpbridge_flagfile  => '/tmp/file'


### PR DESCRIPTION
I missed the feature to let nova auto assign a floating ip therefore I added it with the default of true
