### PR TITLE
Fedora 18+ and EL 7+ feature more granular libvirt packaging

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,7 +12,13 @@ class nova::params {
       $conductor_package_name       = 'openstack-nova-conductor'
       $consoleauth_package_name     = 'openstack-nova-console'
       $doc_package_name             = 'openstack-nova-doc'
-      $libvirt_package_name         = 'libvirt'
+      # Fedora 18+ and EL 7+ have a more granular libvirt packaging.
+      # F17 and older are EOL, so checking for Fedora is good enough.
+      if $::operatingsystem == 'Fedora' or $::operatingsystemrelease >= 7 {
+        $libvirt_package_name         = 'libvirt-daemon-kvm'
+      } else {
+        $libvirt_package_name         = 'libvirt'
+      }
       $network_package_name         = 'openstack-nova-network'
       $numpy_package_name           = 'numpy'
       $objectstore_package_name     = 'openstack-nova-objectstore'


### PR DESCRIPTION
Fedora 18 or later and RHEL (or derivatives) 7 or later feature a
more granular libvirt packaging, thereby allowing to install only
just the necessary packages.

Most notably, this way no default libvirt network is set up. In the
past, the existence of an interface virbr0 with an IPv4 address of
192.168.122.1/24 often caused confusion with users when debugging
network issues.
