### PR TITLE
Add vnc_keymap parameter to nova::compute

### DIFF
--- a/manifests/compute.pp
+++ b/manifests/compute.pp
@@ -40,6 +40,10 @@
 #   (optional) The path at the end of the uri for communication with the VNC proxy server
 #   Defaults to './vnc_auto.html'
 #
+# [*vnc_keymap*]
+#   (optional) The keymap to use with VNC (ls -alh /usr/share/qemu/keymaps to list available keymaps)
+#   Defaults to 'en-us'
+#
 # [*force_config_drive*]
 #   (optional) Whether to force the config drive to be attached to all VMs
 #   Defaults to false
@@ -75,6 +79,7 @@ class nova::compute (
   $vncproxy_protocol             = 'http',
   $vncproxy_port                 = '6080',
   $vncproxy_path                 = '/vnc_auto.html',
+  $vnc_keymap                    = 'en-us',
   $force_config_drive            = false,
   $virtio_nic                    = false,
   $neutron_enabled               = true,
@@ -98,6 +103,7 @@ class nova::compute (
   nova_config {
     'DEFAULT/vnc_enabled':                   value => $vnc_enabled;
     'DEFAULT/vncserver_proxyclient_address': value => $vncserver_proxyclient_address;
+    'DEFAULT/vnc_keymap':                    value => $vnc_keymap;
   }
 
   if $neutron_enabled != true {


### PR DESCRIPTION
I propose to add a optional parameter to nova::compute class:
vnc_keymap
See: http://docs.openstack.org/trunk/config-reference/content/list-of-compute-config-options.html
