### PR TITLE
Don't define virsh secret if already defined

### DIFF
--- a/manifests/compute/rbd.pp
+++ b/manifests/compute/rbd.pp
@@ -77,6 +77,7 @@ class nova::compute::rbd (
 
     exec { 'set-secret-value virsh':
       command => "/usr/bin/virsh secret-set-value --secret $(cat /etc/nova/virsh.secret) --base64 $(ceph auth get-key ${rbd_keyring})",
+      unless => "/usr/bin/virsh secret-list | grep ceph",
       require => Exec['get-or-set virsh secret']
     }
 


### PR DESCRIPTION
We test to see if the ceph secret already has been defined before
installing the secret again.

(This is mainly done to keep our Foreman runs clean, as it reports
on hosts that have had changes applied. Without the 'unless' clause
any node that has the nova compute class installed will report as
having changes applied.
