### PR TITLE
introduce install_occi flag

### DIFF
--- a/manifests/api.pp
+++ b/manifests/api.pp
@@ -159,6 +159,7 @@ class nova::api(
   $api_bind_address      = '0.0.0.0',
   $metadata_listen       = '0.0.0.0',
   $enabled_apis          = 'ec2,osapi_compute,metadata',
+  $install_occi          = true,
   $keystone_ec2_url      = false,
   $volume_api_class      = 'nova.volume.cinder.API',
   $use_forwarded_for     = false,
@@ -316,7 +317,7 @@ class nova::api(
     }
   }
 
-  if 'occiapi' in $enabled_apis {
+  if ('occiapi' in $enabled_apis and $install_occi) {
     if !defined(Package['python-pip']) {
       package { 'python-pip':
         ensure => latest,


### PR DESCRIPTION
occi is not available for the latest openstack versions (until now). If it becomes available, then probably not through pip but only through github. The pip package is referring to a essex version and puppet is failing with:

Could not update: Execution of '/usr/bin/pip install -q --upgrade openstackocci' returned 1: Could not find a version that satisfies the requirement openstackocci (from versions: essex-1.1) No distributions matching the version for openstackocci Storing debug log for failure in /root/.pip/pip.log

therefore introduce a flag that allows to have occi enabled (in the pipeline) but does not install it via pip.

