### PR TITLE
ensure rabbit_host and rabbit_userid are absent in DEFAULT section

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -773,5 +773,7 @@ class nova(
   # Deprecated in Juno, removed in Kilo
   nova_config {
     'DEFAULT/os_region_name':       ensure => absent;
+    'DEFAULT/rabbit_userid':        ensure => absent;
+    'DEFAULT/rabbit_host':          ensure => absent;
   }
 }


### PR DESCRIPTION
This will fix [bug] (https://bugs.launchpad.net/puppet-nova/+bug/1529475) by removing rabbit_host and rabbit_userid from `[DEFAULT]`