### PR TITLE
Fix libvirtd_opts when using systemd

### DIFF
--- a/manifests/migration/libvirt.pp
+++ b/manifests/migration/libvirt.pp
@@ -159,9 +159,17 @@ class nova::migration::libvirt(
         }
       }
 
+      if $::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemmajrelease, '16') >= 0 {
+        # If systemd is being used then libvirtd is already being launched correctly and
+        # adding -d causes a second consecutive start to fail which causes puppet to fail.
+        $libvirtd_opts = 'libvirtd_opts="-l"'
+      } else {
+        $libvirtd_opts = 'libvirtd_opts="-d -l"'
+      }
+
       file_line { "/etc/default/${::nova::compute::libvirt::libvirt_service_name} libvirtd opts":
         path  => "/etc/default/${::nova::compute::libvirt::libvirt_service_name}",
-        line  => 'libvirtd_opts="-d -l"',
+        line  => $libvirtd_opts,
         match => 'libvirtd_opts=',
         tag   => 'libvirt-file_line',
       }

--- a/spec/classes/nova_compute_libvirt_spec.rb
+++ b/spec/classes/nova_compute_libvirt_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'puppet/util/package'
 describe 'nova::compute::libvirt' do
 
   let :pre_condition do
@@ -6,6 +7,14 @@ describe 'nova::compute::libvirt' do
   end
 
   shared_examples 'debian-nova-compute-libvirt' do
+    let(:libvirt_options) do
+      if facts[:operatingsystem] == 'Ubuntu' and Puppet::Util::Package.versioncmp(facts[:operatingsystemmajrelease], '16') >= 0
+        'libvirtd_opts="-l"'
+      else
+        'libvirtd_opts="-d -l"'
+      end
+    end
+
     describe 'with default parameters' do
 
       it { is_expected.to contain_class('nova::params')}
@@ -123,7 +132,7 @@ describe 'nova::compute::libvirt' do
 
         it { is_expected.to contain_class('nova::migration::libvirt')}
         it { is_expected.to contain_nova_config('vnc/vncserver_listen').with_value('0.0.0.0')}
-        it { is_expected.to contain_file_line('/etc/default/libvirt-bin libvirtd opts').with(:line => 'libvirtd_opts="-d -l"') }
+        it { is_expected.to contain_file_line('/etc/default/libvirt-bin libvirtd opts').with(:line => libvirt_options) }
         it { is_expected.to contain_file_line('/etc/libvirt/libvirtd.conf listen_tls').with(:line => "listen_tls = 0") }
         it { is_expected.to contain_file_line('/etc/libvirt/libvirtd.conf listen_tcp').with(:line => "listen_tcp = 1") }
         it { is_expected.not_to contain_file_line('/etc/libvirt/libvirtd.conf auth_tls')}
@@ -138,7 +147,7 @@ describe 'nova::compute::libvirt' do
 
         it { is_expected.to contain_class('nova::migration::libvirt')}
         it { is_expected.to contain_nova_config('vnc/vncserver_listen').with_value('::0')}
-        it { is_expected.to contain_file_line('/etc/default/libvirt-bin libvirtd opts').with(:line => 'libvirtd_opts="-d -l"') }
+        it { is_expected.to contain_file_line('/etc/default/libvirt-bin libvirtd opts').with(:line => libvirt_options) }
         it { is_expected.to contain_file_line('/etc/libvirt/libvirtd.conf listen_tls').with(:line => "listen_tls = 0") }
         it { is_expected.to contain_file_line('/etc/libvirt/libvirtd.conf listen_tcp').with(:line => "listen_tcp = 1") }
         it { is_expected.not_to contain_file_line('/etc/libvirt/libvirtd.conf auth_tls')}
@@ -151,7 +160,7 @@ describe 'nova::compute::libvirt' do
             :vncserver_listen      => '0.0.0.0',
             :migration_support     => true }
         end
-        it { is_expected.to contain_file_line('/etc/default/libvirtd libvirtd opts').with(:line => 'libvirtd_opts="-d -l"') }
+        it { is_expected.to contain_file_line('/etc/default/libvirtd libvirtd opts').with(:line => libvirt_options) }
 
       end
     end
@@ -320,19 +329,21 @@ describe 'nova::compute::libvirt' do
       @default_facts.merge({
         :osfamily => 'Debian',
         :operatingsystem => 'Debian',
-        :os_package_family => 'debian'
+        :os_package_family => 'debian',
+        :operatingsystemmajrelease => '8'
       })
     end
 
     it_behaves_like 'debian-nova-compute-libvirt'
   end
 
-  context 'on Debian platforms' do
+  context 'on Ubuntu platforms' do
     let (:facts) do
       @default_facts.merge({
         :osfamily => 'Debian',
         :operatingsystem => 'Ubuntu',
-        :os_package_family => 'ubuntu'
+        :os_package_family => 'ubuntu',
+        :operatingsystemmajrelease => '16.04'
       })
     end
 
@@ -343,7 +354,7 @@ describe 'nova::compute::libvirt' do
     let (:facts) do
       @default_facts.merge({
         :osfamily => 'RedHat',
-        :os_package_type => 'rpm'
+        :os_package_type => 'rpm',
       })
     end
 

--- a/spec/classes/nova_migration_libvirt_spec.rb
+++ b/spec/classes/nova_migration_libvirt_spec.rb
@@ -119,9 +119,27 @@ describe 'nova::migration::libvirt' do
     end
   end
 
-  context 'on Debian platforms' do
+  # TODO (degorenko): switch to on_supported_os function when we got Xenial
+  context 'on Debian platforms with Ubuntu release 16' do
     let :facts do
-      @default_facts.merge({ :osfamily => 'Debian' })
+      @default_facts.merge({
+        :osfamily => 'Debian',
+        :operatingsystem => 'Ubuntu',
+        :operatingsystemmajrelease => '16'
+      })
+    end
+
+    it_configures 'nova migration with libvirt'
+    it { is_expected.to contain_file_line('/etc/default/libvirt-bin libvirtd opts').with(:line => 'libvirtd_opts="-l"') }
+  end
+
+  context 'on Debian platforms release' do
+    let :facts do
+      @default_facts.merge({
+        :osfamily => 'Debian',
+        :operatingsystem => 'Debian',
+        :operatingsystemmajrelease => '8'
+      })
     end
 
     it_configures 'nova migration with libvirt'
@@ -130,7 +148,11 @@ describe 'nova::migration::libvirt' do
 
   context 'on RedHat platforms' do
     let :facts do
-      @default_facts.merge({ :osfamily => 'RedHat' })
+      @default_facts.merge({
+        :osfamily => 'RedHat',
+        :operatingsystem => 'CentOS',
+        :operatingsystemmajrelease => '7.0'
+      })
     end
 
     it_configures 'nova migration with libvirt'


### PR DESCRIPTION
Hi,

Cherry picked this to enable using Mitaka on Ubuntu xenial with systemd.
Not sure if this is the right way to get it merged into the stable/mitaka branch - so if this is not correct please let me know show I need to change to get this in.

Thanks!


> You see the following error when using puppet:
> Error: Could not start Service[libvirt]: Execution of '/bin/systemctl
> start libvirt-bin' returned 1: Job for libvirt-bin.service failed
> because the control process exited with error code. See "systemctl
> status libvirt-bin.service" and "journalctl -xe" for details.
> 
> This is because you cannot start the libvirt-bin service twice in a row.
> 
> root@pkvmci829:~# systemctl start libvirt-bin
> root@pkvmci829:~# systemctl start libvirt-bin
> Job for libvirt-bin.service failed because the control process exited
> with error code. See "systemctl status libvirt-bin.service" and
> "journalctl -xe" for details.
> 
> Systemd already is able to start libvirtd as a daemon.  It does not need
> the -d parameter added to /etc/default/libvirt-bin.  This just causes
> systemd to keep respawning libvirtd in a loop until it realizes that it
> isn't working.
> 
> Change-Id: Iaffe85dda5c5bfed88f27602189aca074ec7aeda
> (cherry picked from commit 841cfd770c1236cdb57b44a17fc781fd24816f0e)