### PR TITLE
Fix invalid PCI alias definition

### DIFF
--- a/manifests/api.pp
+++ b/manifests/api.pp
@@ -525,7 +525,7 @@ as a standalone service, or httpd for being run by a httpd server")
 
   if $pci_alias {
     nova_config {
-      'DEFAULT/pci_alias': value => check_array_of_hash($pci_alias);
+      'DEFAULT/pci_alias': value => join(any2array(check_array_of_hash($pci_alias)), ',');
     }
   }
 


### PR DESCRIPTION
The PCI alias config type is changed in recent release from
'oslo_config.ListOpt' to 'oslo_config.MultiStrOpt'.

Here nova expects a multi valued option instead of a list.

Conflicts:
        manifests/api.pp

Change-Id: Ie27dbbc510c73c685b239a9be4af2700a0eb42f0
Closes-Bug: #1696955
(cherry picked from commit 9dde5a4108df2448bfd43010112d313f1a73395b)
(cherry picked from commit 1f4356c8b1b3fc3963df7768a32ecc46cfcfd31d)