### PR TITLE
Add the otpion to only aggregate hosts known to be active by openstack.

### DIFF
--- a/lib/puppet/provider/nova_aggregate/openstack.rb
+++ b/lib/puppet/provider/nova_aggregate/openstack.rb
@@ -21,7 +21,8 @@ Puppet::Type.type(:nova_aggregate).provide(
           :id => attrs[:id],
           :availability_zone => attrs[:availability_zone],
           :metadata => str2hash(attrs[:properties]),
-          :hosts => string2list(attrs[:hosts]).sort
+          :hosts => string2list(attrs[:hosts]).sort,
+          :filter_hosts => attrs[:filter_hosts]
       )
     end
   end
@@ -37,6 +38,11 @@ Puppet::Type.type(:nova_aggregate).provide(
         resources[name].provider = provider
       end
     end
+  end
+
+  def self.get_known_hosts
+    # get list of hosts known to be active from openstack
+    return request('compute service', 'list', ['--service', 'nova-compute']).map{|el| el[:host]}
   end
 
   def exists?
@@ -62,8 +68,11 @@ Puppet::Type.type(:nova_aggregate).provide(
       end
     end
     @property_hash = self.class.request('aggregate', 'create', properties)
-
     if not @resource[:hosts].nil? and not @resource[:hosts].empty?
+      # filter host list by known hosts if filter_hosts is set
+      if @resource[:filter_hosts] == :true
+        @resource[:hosts] = @resource[:hosts] & self.class.get_known_hosts()
+      end
       @resource[:hosts].each do |host|
         properties = [@property_hash[:name], host]
         self.class.request('aggregate', 'add host', properties)
@@ -93,15 +102,20 @@ Puppet::Type.type(:nova_aggregate).provide(
   end
 
   def hosts=(value)
-    # remove hosts, which are not present in update
-    (@property_hash[:hosts] - @resource[:hosts]).each do |host|
-      properties = [@property_hash[:id], host]
-      self.class.request('aggregate', 'remove host', properties)
+    # filter host list by known hosts if filter_hosts is set
+    if @resource[:filter_hosts] == :true
+      value &= self.class.get_known_hosts()
     end
-    # add new hosts
-    (@resource[:hosts] - @property_hash[:hosts]).each do |host|
-      properties = [@property_hash[:id], host]
-      self.class.request('aggregate', 'add host', properties)
+    if not @property_hash[:hosts].nil?
+      # remove hosts that are not present in update
+      (@property_hash[:hosts] - value).each do |host|
+        self.class.request('aggregate', 'remove host', [@property_hash[:id], host])
+      end
+      # add hosts that are not already present
+      (value - @property_hash[:hosts]).each do |host|
+        self.class.request('aggregate', 'add host', [@property_hash[:id], host])
+      end
     end
   end
+
 end

--- a/lib/puppet/type/nova_aggregate.rb
+++ b/lib/puppet/type/nova_aggregate.rb
@@ -23,6 +23,11 @@
 #    Name for the new aggregate
 #    Required
 #
+#  [*filter_hosts*]
+#    A boolean-y value to toggle whether only hosts known to be active by
+#    openstack should be aggregated. i.e. "true" or "false"
+#    Optional, defaults to "false"
+#
 #  [*availability_zone*]
 #    The availability zone. ie "zone1"
 #    Optional
@@ -58,6 +63,12 @@ Puppet::Type.newtype(:nova_aggregate) do
         raise ArgumentError, "#{value} is not a valid name"
       end
     end
+  end
+
+  newparam(:filter_hosts) do
+    desc 'Toggle to filter given hosts so that only known nova-compute service hosts are added to the aggregate'
+    defaultto :false
+    newvalues(:true, :false)
   end
 
   newproperty(:id) do

--- a/spec/unit/type/nova_aggregate_spec.rb
+++ b/spec/unit/type/nova_aggregate_spec.rb
@@ -30,4 +30,13 @@ describe Puppet::Type.type(:nova_aggregate) do
     }
     expect { Puppet::Type.type(:nova_aggregate).new(incorrect_input) }.to raise_error(Puppet::ResourceError, /availability zone must be a String/)
   end
+
+  it 'should raise error if non-boolean-y input for filter_hosts' do
+    incorrect_input = {
+      :name => 'new_aggr',
+      :filter_hosts => 'some non boolean-y value',
+    }
+    expect { Puppet::Type.type(:nova_aggregate).new(incorrect_input) }.to raise_error(Puppet::ResourceError, /Valid values are true, false./)
+  end
+
 end


### PR DESCRIPTION
Adds a flag to the nova-aggregate type to allow the provider to only aggregate hosts that are currently known to be active by openstack.